### PR TITLE
Add laravel 5.4 and 5.7 in require-dev composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",
-        "laravel/framework": "~5.5.0|~5.6.0",
+        "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0",
         "orchestra/testbench": "~3.4.0|~3.5.0|~3.6.0"
     },
     "autoload": {


### PR DESCRIPTION
Add laravel ~5.4.0 and ~5.7.0 match to *require* in composer.json and *Requirements* in documents.