### PR TITLE
[Enhancement] a bit dirty allowing different guard per published version

### DIFF
--- a/publishable/config/larecipe.php
+++ b/publishable/config/larecipe.php
@@ -34,7 +34,17 @@ return [
     'versions'      => [
         'default'   => '1.0',
         'published' => [
-            '1.0'
+            [
+                'version' => '1.0',
+                'auth'  => false,
+                'guard'  => 'web',
+                'auth_links' => [
+                    [
+                        'name' => '',
+                        'url' => '',
+                    ],
+                ],
+            ]
         ]
     ],
 
@@ -54,13 +64,6 @@ return [
     */
 
     'settings' => [
-        'auth'  => false,
-        'auth_links' => [
-            [
-                'name' => '',
-                'url' => '',
-            ],
-        ],
         'ga_id' => ''
     ],
 

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -90,7 +90,7 @@
 
             @foreach ($versions as $version)
 				<li role="presentation">
-					<a class="dropdown-item" href="{{ url(config('larecipe.docs.route').'/'.$version.$currentSection) }}">{{ $version }}</a>
+					<a class="dropdown-item" href="{{ url(config('larecipe.docs.route').'/'.$version['version'].$currentSection) }}">{{ $version['version'] }}</a>
 				</li>
 			@endforeach
         </larecipe-dropdown>

--- a/src/Commands/GenerateDocumentationCommand.php
+++ b/src/Commands/GenerateDocumentationCommand.php
@@ -47,9 +47,8 @@ class GenerateDocumentationCommand extends Command
      */
     public function handle()
     {
-        $publishedVersions = config('larecipe.versions.published');
-
-        $this->info('Reading all docs versions, found: '.implode(collect($publishedVersions)->pluck('version')->toArray()), ',');
+        $publishedVersions = collect(config('larecipe.versions.published'))->pluck('version')->toArray();
+        $this->info('Reading all docs versions, found: '.implode($publishedVersions), ',');
         foreach ($publishedVersions as $version) {
             $versionDirectory = config('larecipe.docs.path').'/'.$version;
 

--- a/src/Commands/GenerateDocumentationCommand.php
+++ b/src/Commands/GenerateDocumentationCommand.php
@@ -49,7 +49,7 @@ class GenerateDocumentationCommand extends Command
     {
         $publishedVersions = config('larecipe.versions.published');
 
-        $this->info('Reading all docs versions, found: '.implode( collect($publishedVersions)->pluck('version')->toArray() ), ',');
+        $this->info('Reading all docs versions, found: '.implode(collect($publishedVersions)->pluck('version')->toArray()), ',');
         foreach ($publishedVersions as $version) {
             $versionDirectory = config('larecipe.docs.path').'/'.$version;
 

--- a/src/Commands/GenerateDocumentationCommand.php
+++ b/src/Commands/GenerateDocumentationCommand.php
@@ -49,7 +49,7 @@ class GenerateDocumentationCommand extends Command
     {
         $publishedVersions = config('larecipe.versions.published');
 
-        $this->info('Reading all docs versions, found: '.implode($publishedVersions), ',');
+        $this->info('Reading all docs versions, found: '.implode( collect($publishedVersions)->pluck('version')->toArray() ), ',');
         foreach ($publishedVersions as $version) {
             $versionDirectory = config('larecipe.docs.path').'/'.$version;
 

--- a/src/Commands/IndexDocumentationCommand.php
+++ b/src/Commands/IndexDocumentationCommand.php
@@ -30,8 +30,8 @@ class IndexDocumentationCommand extends Command
         $this->line('Reading published versions..');
         $publishedVersions = config('larecipe.versions.published');
 
-        foreach ($publishedVersions as $version) {
-            $this->info('Reading index.md for v'.$version);
+        foreach ($publishedVersions as $published) {
+            $this->info('Reading index.md for v'.$published['version']);
             // $this->documentationIndex($version);
         }
     }

--- a/src/DocumentationRepository.php
+++ b/src/DocumentationRepository.php
@@ -122,7 +122,7 @@ class DocumentationRepository
      */
     public function isPublishedVersion($version)
     {
-        return in_array($version, $this->publishedVersions);
+        return in_array($version, collect($this->publishedVersions)->pluck('version')->toArray());
     }
 
     /**

--- a/src/Http/Controllers/DocumentationController.php
+++ b/src/Http/Controllers/DocumentationController.php
@@ -18,10 +18,6 @@ class DocumentationController extends Controller
     public function __construct(DocumentationRepository $documentationRepository)
     {
         $this->documentationRepository = $documentationRepository;
-
-        if (config('larecipe.settings.auth')) {
-            $this->middleware(['auth']);
-        }
     }
 
     /**
@@ -49,6 +45,17 @@ class DocumentationController extends Controller
 
         if (Gate::has('viewLarecipe')) {
             $this->authorize('viewLarecipe', $documentation);
+        }
+
+        $published_versions_config = collect($this->documentationRepository->publishedVersions)->keyBy('version');
+        if(
+            isset($published_versions_config[$version])
+            && isset($published_versions_config[$version]['auth'])
+            && $published_versions_config[$version]['auth']
+        ){
+            if( !auth()->guard($published_versions_config[$version]['guard'])->check() ){
+                return redirect('login');
+            }
         }
 
         if ($this->documentationRepository->isNotPublishedVersion($version)) {

--- a/src/Http/Controllers/DocumentationController.php
+++ b/src/Http/Controllers/DocumentationController.php
@@ -48,12 +48,12 @@ class DocumentationController extends Controller
         }
 
         $published_versions_config = collect($this->documentationRepository->publishedVersions)->keyBy('version');
-        if(
+        if (
             isset($published_versions_config[$version])
             && isset($published_versions_config[$version]['auth'])
             && $published_versions_config[$version]['auth']
-        ){
-            if( !auth()->guard($published_versions_config[$version]['guard'])->check() ){
+        ) {
+            if (! auth()->guard($published_versions_config[$version]['guard'])->check()) {
                 return redirect('login');
             }
         }

--- a/tests/Feature/ShowDocumentationTest.php
+++ b/tests/Feature/ShowDocumentationTest.php
@@ -25,7 +25,7 @@ class ShowDocumentationTest extends TestCase
         Config::set('larecipe.docs.landing', 'foo');
 
         // set auth to false
-        Config::set('larecipe.settings.auth', false);
+        Config::set('larecipe.versions.published.0.auth', false);
         
         // guest can view foo page
         $this->get('/docs/1.0')
@@ -50,7 +50,7 @@ class ShowDocumentationTest extends TestCase
         // set the docs path and landing
         Config::set('larecipe.docs.path', 'tests/views/docs');
         Config::set('larecipe.docs.landing', 'foo');
-        Config::set('larecipe.versions.published', ['1.0']);
+        Config::set('larecipe.versions.published', [ [ 'version' => '1.0' ] ]);
 
         
         // guest can view foo page
@@ -75,7 +75,11 @@ class ShowDocumentationTest extends TestCase
     /** @test */
     public function only_auth_user_can_visit_docs_if_auth_option_is_enabled()
     {
-        Config::set('larecipe.settings.auth', true);
+        Config::set('larecipe.versions.published.0', [
+            'version' => '1.0',
+            'auth' => true,
+            'guard' => 'web'
+        ]);
 
         $this->get('/docs/1.0')->assertRedirect('login');
     }


### PR DESCRIPTION
With passing tests.

This allows to have different guard per published version. 
Could be something like:

```
 'versions'=> [
        'default'   => 'user-1.0',
        'published' => [
            [
                'version' => 'user-1.0',
                'auth'  => true,
                'guard'  => 'web',
                'auth_links' => [
                    [
                        'name' => '',
                        'url' => '',
                    ],
                ],
            ],
            [
                'version' => 'admin-1.0',
                'auth'  => true,
                'guard'  => 'admin',
                'auth_links' => [
                    [
                        'name' => '',
                        'url' => '',
                    ],
                ],
            ]
        ]
    ],
```