### PR TITLE
Make the mediumZoom selector more specific

### DIFF
--- a/publishable/assets/js/app.js
+++ b/publishable/assets/js/app.js
@@ -2305,7 +2305,7 @@ var app = new __WEBPACK_IMPORTED_MODULE_0_vue___default.a({
     this.activateCurrentSection();
     this.parseDocsContent();
     this.setupKeyboardShortcuts();
-    Object(__WEBPACK_IMPORTED_MODULE_1_medium_zoom__["a" /* default */])('img');
+    Object(__WEBPACK_IMPORTED_MODULE_1_medium_zoom__["a" /* default */])('.documentation .article img');
   },
 
   methods: {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -32,7 +32,7 @@ const app = new Vue({
     this.activateCurrentSection()
     this.parseDocsContent()
     this.setupKeyboardShortcuts()
-    mediumZoom('img')
+    mediumZoom('.documentation .article img')
   },
   methods: {
     handleSidebarVisibility() {


### PR DESCRIPTION
First off, awesome project! Thank you!

I am using v1.2.5 and discovered with the addition of medium-zoom, it also zooms the logo. This PR is to make the selector more specific so only images within a page of documentation gets zoomed.

