### PR TITLE
 feat: add configurable nav links 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,13 @@
 {
     "name": "binarytorch/larecipe",
     "description": "Generate gorgeous recipes for your Laravel applications using MarkDown",
-    "keywords": ["laravel", "markdown", "docs", "documentation", "api"],
+    "keywords": [
+        "laravel",
+        "markdown",
+        "docs",
+        "documentation",
+        "api"
+    ],
     "license": "MIT",
     "type": "library",
     "support": {
@@ -33,7 +39,7 @@
     "autoload-dev": {
         "psr-4": {
             "BinaryTorch\\LaRecipe\\Tests\\": "tests/"
-      }
+        }
     },
     "minimum-stability": "stable",
     "extra": {
@@ -42,5 +48,9 @@
                 "BinaryTorch\\LaRecipe\\LaRecipeServiceProvider"
             ]
         }
+    },
+    "scripts": {
+        "test": "\"vendor/bin/phpunit\"",
+        "test:coverage": "\"vendor/bin/phpunit\" --coverage-html coverage"
     }
 }

--- a/publishable/config/larecipe.php
+++ b/publishable/config/larecipe.php
@@ -172,12 +172,12 @@ return [
     */
 
     'nav'                => [
-        // [
-        //     'url' => 'https://larecipe.binarytorch.com.my/docs/1.3/overview',
-        //     'text' => 'LaRecipe',
-        //     'icon' => 'heart',
-        //     'type' => 'outline-info'
-        // ],
+        [
+            'url'        => 'https://larecipe.binarytorch.com.my/docs/1.3/overview',
+            'text'       => 'LaRecipe',
+            'icon'       => 'heart',
+            'type'       => 'outline-info'
+        ],
     ],
 
     /*

--- a/publishable/config/larecipe.php
+++ b/publishable/config/larecipe.php
@@ -157,7 +157,27 @@ return [
         ],
         'additional_js'  => [
             //'js/custom.js',
-        ],
+        ]
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Navigation
+    |--------------------------------------------------------------------------
+    |
+    | Here you can add links to the navbar. 
+    | Link type defaults to "outline-primary". Icon and text are not required.
+    |
+    */
+
+    'nav'                => [
+        // [
+        //     'url' => 'https://larecipe.binarytorch.com.my/docs/1.3/overview',
+        //     'text' => 'LaRecipe',
+        //     'icon' => 'heart',
+        //     'type' => 'outline-info'
+        // ],
     ],
 
     /*

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -70,6 +70,26 @@
             {{-- /search button --}}
         @endif
 
+        {{-- configurable links --}}
+        @foreach (config('larecipe.nav') as $nav)
+        <larecipe-button tag="a"
+            @isset($nav['url'])
+                href="{{ $nav['url'] }}"
+            @endisset 
+            slot="title" 
+            type="{{ isset($nav['type']) ? $nav['type'] : 'outline-primary' }}" 
+            style="width: 100%">
+            @isset($nav['icon'])
+                <i class="fa fa-{{ $nav['icon'] }}"></i> 
+            @endisset
+            
+            @isset($nav['text'])
+                {{ $nav['text'] }}
+            @endisset
+        </larecipe-button>
+        @endforeach
+        {{-- /configurable links --}}
+
         {{-- repository link --}}
         @if (config('larecipe.repository.url'))
             <larecipe-button tag="a" id="repository_button" 

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -127,4 +127,29 @@ class ConfigurationTest extends TestCase
         $this->get('/docs/1.0')
             ->assertSee('disqus_thread');
     }
+
+    /** @test */
+    public function nav_link_configuration()
+    {
+        Config::set('larecipe.nav', []);
+        $this->get('/docs/1.0')
+            ->assertDontSee('NavLinkConfig')
+            ->assertDontSee('NavLinkIcon')
+            ->assertDontSee('NavLinkType')
+            ->assertDontSee('NavLinkUrl');
+
+        Config::set('larecipe.nav', [
+            [
+                'url' => 'NavLinkUrl',
+                'text' => 'NavLinkConfig',
+                'icon' => 'NavLinkIcon',
+                'type' => 'NavLinkType'
+            ]
+        ]);
+        $this->get('/docs/1.0')
+            ->assertSee('NavLinkConfig')
+            ->assertSee('NavLinkIcon')
+            ->assertSee('NavLinkType')
+            ->assertSee('NavLinkUrl');
+    }
 }


### PR DESCRIPTION
If approved, [configurations.md](https://github.com/saleem-hadad/larecipe-docs/blob/1.3/configurations.md) should be updated with something like the following:

```markdown
<a name="nav"></a>
## Navigation
Here you can configure additional links for the navbar.

```php
return [
   'nav'                => [
      [
          'url'         => 'https://larecipe.binarytorch.com.my/docs/1.3/overview',
          'text'        => 'LaRecipe',
          'icon'        => 'heart',
          'type'        => 'outline-info'
      ],
   ]
]
```