### PR TITLE
Expand Test Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: true
 php:
 - 7.1
 - 7.2
+- 7.3
 
 services:
 - sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 sudo: true
 
 php:
+- 5.6
 - 7.1
 - 7.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: true
 
 php:
-- 5.6
 - 7.1
 - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,15 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.4.0",
-        "illuminate/view": "~5.4.0",
+        "php": ">=7.1",
+        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/view": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "erusev/parsedown-extra": "^0.7.1",
         "symfony/dom-crawler": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0|~7.5",
-        "laravel/framework": "~5.4.0",
+        "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "orchestra/testbench": "~3.4.0|~3.5.0|~3.6.0|~3.7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/view": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/support": "~5.4.0",
+        "illuminate/view": "~5.4.0",
         "erusev/parsedown-extra": "^0.7.1",
         "symfony/dom-crawler": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0|~7.5",
-        "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "laravel/framework": "~5.4.0",
         "orchestra/testbench": "~3.4.0|~3.5.0|~3.6.0|~3.7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.1.3",
         "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "illuminate/view": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "erusev/parsedown-extra": "^0.7.1",
@@ -24,7 +24,7 @@
     "require-dev": {
         "phpunit/phpunit": "~7.0|~7.5",
         "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "orchestra/testbench": "~3.4.0|~3.5.0|~3.6.0|~3.7.0"
+        "orchestra/testbench": "~3.4.0|~3.5.0|~3.6.0|~3.7.0|~3.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Feature/BuiltInSearchTest.php
+++ b/tests/Feature/BuiltInSearchTest.php
@@ -10,7 +10,7 @@ class BuiltInSearchTest extends TestCase
 {
     protected $documentation;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use BinaryTorch\LaRecipe\LaRecipeServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
-    public function setup()
+    public function setup(): void
     {
         parent::setup();
         

--- a/tests/Unit/DocumentationRepositoryTest.php
+++ b/tests/Unit/DocumentationRepositoryTest.php
@@ -10,7 +10,7 @@ class DocumentationRepositoryTest extends TestCase
 {
     protected $documentationRepository;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/DocumentationTest.php
+++ b/tests/Unit/DocumentationTest.php
@@ -11,7 +11,7 @@ class DocumentationTest extends TestCase
 {
     protected $documentation;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
There are quite a few commits, but those were just to test current state of the package.

## This PR is to extend the test coverage for the package

Currently, the package does not specify a minimum PHP version. This PR will require at least `PHP 7.1.3` which is the minimum requirement for `"symfony/dom-crawler": "^4.1"`.

This PR also adds a new version of `orchestra/testbench` which allows testing to run against `Laravel 5.8`.

In order for tests to pass in `Laravel 5.8`, I also had to add `void` return type to the `setUp` methods in the tests.

Last but not least, this PR also adds a new PHP version for the package to be tested against - `PHP 7.3`