### PR TITLE
Check for Laravel version and change cache from minutes to seconds

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -29,15 +29,21 @@ class Cache
      *
      * @param  \Closure  $callback
      * @param  string  $key
-     * @return void
+     * @return mixed
      */
     public function remember(\Closure $callback, $key)
     {
+        $app_version = app()->version();
+
         if (! config('larecipe.cache.enabled')) {
             return $callback();
         }
 
         $cachePeriod = config('larecipe.cache.period');
+
+        if ((int) $app_version[0] >= 5 && (int) $app_version[1] >= 8) {
+            $cachePeriod = config('larecipe.cache.period') * 60;
+        }
 
         return $this->cache->remember($key, $cachePeriod, $callback);
     }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -33,15 +33,15 @@ class Cache
      */
     public function remember(\Closure $callback, $key)
     {
-        $app_version = app()->version();
-
         if (! config('larecipe.cache.enabled')) {
             return $callback();
         }
 
         $cachePeriod = config('larecipe.cache.period');
 
-        if ((int) $app_version[0] >= 5 && (int) $app_version[1] >= 8) {
+        $app_version = app()->version();
+        
+        if (((int) $app_version[0] == 5 && (int) $app_version[1] >= 8) || $app_version[0] > 5) {
             $cachePeriod = config('larecipe.cache.period') * 60;
         }
 

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -39,7 +39,7 @@ class Cache
 
         $cachePeriod = config('larecipe.cache.period');
 
-        $app_version = app()->version();
+        $app_version = explode('.', app()->version());
         
         if (((int) $app_version[0] == 5 && (int) $app_version[1] >= 8) || $app_version[0] > 5) {
             $cachePeriod = config('larecipe.cache.period') * 60;

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -37,14 +37,26 @@ class Cache
             return $callback();
         }
 
-        $cachePeriod = config('larecipe.cache.period');
-
-        $app_version = explode('.', app()->version());
-        
-        if (((int) $app_version[0] == 5 && (int) $app_version[1] >= 8) || $app_version[0] > 5) {
-            $cachePeriod = config('larecipe.cache.period') * 60;
-        }
+        $cachePeriod = $this->checkTtlNeedsChanged(config('larecipe.cache.period'));
 
         return $this->cache->remember($key, $cachePeriod, $callback);
+    }
+
+    /**
+     * Checks if minutes need to be changed to seconds
+     *
+     * @param $ttl
+     *
+     * @return float|int
+     */
+    public function checkTtlNeedsChanged($ttl)
+    {
+        $app_version = explode('.', app()->version());
+
+        if (((int) $app_version[0] == 5 && (int) $app_version[1] >= 8) || $app_version[0] > 5) {
+            return config('larecipe.cache.period') * 60;
+        }
+
+        return $ttl;
     }
 }

--- a/tests/Unit/DocumentationTest.php
+++ b/tests/Unit/DocumentationTest.php
@@ -38,11 +38,15 @@ class DocumentationTest extends TestCase
     /** @test */
     public function it_caches_the_requested_documentation_and_index_for_a_given_period()
     {
+        $cache = $this->app->make(\BinaryTorch\LaRecipe\Cache::class);
+        $app_version = explode('.', app()->version());
+
         // set the docs path and landing
         Config::set('larecipe.docs.path', 'tests/views/docs');
         Config::set('larecipe.docs.landing', 'foo');
         Config::set('larecipe.versions.default', '1.0');
-        Config::set('larecipe.cache.enabled', '1.0');
+        Config::set('larecipe.cache.enabled', true);
+        Config::set('larecipe.cache.period', 300);
 
         $this->documentation->getIndex('1.0');
         $this->assertNotEmpty(cache('larecipe.docs.1.0.index'));
@@ -52,6 +56,12 @@ class DocumentationTest extends TestCase
 
         $this->documentation->get('1.0', 'bar');
         $this->assertNull(cache('larecipe.docs.1.0.bar'));
+
+        if (((int) $app_version[0] == 5 && (int) $app_version[1] >= 8) || $app_version[0] > 5) {
+            $this->assertEquals($cache->checkTtlNeedsChanged(300), 300 * 60);
+        } else {
+            $this->assertEquals($cache->checkTtlNeedsChanged(300), 300);
+        }
     }
 
     /** @test */


### PR DESCRIPTION
Starting in Laravel 5.8 the [cache now takes time in seconds instead of minutes](https://laravel.com/docs/5.8/upgrade#cache-ttl-in-seconds). This PR checks if the app is running `Laravel >= 5.8` and transforms the TTL to seconds.