### PR TITLE
Use route redirect with parameters

### DIFF
--- a/src/Http/Controllers/DocumentationController.php
+++ b/src/Http/Controllers/DocumentationController.php
@@ -31,9 +31,13 @@ class DocumentationController extends Controller
      */
     public function index()
     {
-        $redirectURL = config('larecipe.versions.default').'/'.config('larecipe.docs.landing');
-
-        return redirect()->route('larecipe.show', $redirectURL);
+        return redirect()->route(
+            'larecipe.show',
+            [
+                'version' => config('larecipe.versions.default'),
+                'page' => config('larecipe.docs.landing')
+            ]
+        );
     }
 
     /**
@@ -52,7 +56,13 @@ class DocumentationController extends Controller
         }
 
         if ($this->documentationRepository->isNotPublishedVersion($version)) {
-            return redirect($documentation->defaultVersionUrl.'/'.$page, 301);
+            return redirect()->route(
+                'larecipe.show',
+                [
+                    'version' => config('larecipe.versions.default'),
+                    'page' => config('larecipe.docs.landing')
+                ]
+            );
         }
 
         return response()->view('larecipe::docs', [


### PR DESCRIPTION
In my opinion it is better to use native Laravel router to perform redirects, than creating own URL. So I changed it little bit.

And I also removed 301 Redirect code, because it is cached for really long time. If someone try to access not published version, it could be super hard to get there when it will be published finally.

As there is no functionality change, also no test is added/changed