### PR TITLE
fix "Undefined offset: 1" error when searching

### DIFF
--- a/src/Traits/Indexable.php
+++ b/src/Traits/Indexable.php
@@ -17,7 +17,7 @@ trait Indexable
 
             $result = [];
             foreach($pages as $page) {
-                $page = explode('{{version}}', $page)[1];
+                $page = explode($version, $page)[1];
                 $pageContent = $this->get($version, $page);
 
                 if(! $pageContent)


### PR DESCRIPTION
fix "Undefined offset: 1" error when searching