### PR TITLE
Add base href pointing to Config::get('app.url')

### DIFF
--- a/resources/views/default.blade.php
+++ b/resources/views/default.blade.php
@@ -45,6 +45,9 @@
         @foreach(LaRecipe::allStyles() as $name => $path)
             <link rel="stylesheet" href="{{ route('larecipe.styles', $name) }}">
         @endforeach
+		
+		<!-- Base url -->
+		<base href="{{ Config::get('app.url') }}/" />
     </head>
     <body>
         <div id="app" v-cloak>


### PR DESCRIPTION
Links to other markdown pages should have a correct relative path.

When being on a documentation page, for example
`mydomain.com/docs/1.0/overview`, a link to `[General](docs/1.0/general)` compiles to `mydomain.com/docs/1.0/docs/1.0/site-examinfo`

Putting a base href property to `Config::get('app.url')` fixes it