### PR TITLE
Use middleware if auth boolean is false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
 - travis_retry composer self-update
 - travis_retry composer update --no-interaction --prefer-dist
 - composer show laravel/framework
+- composer dump-autoload
 
 script:
 - vendor/bin/phpunit

--- a/publishable/config/larecipe.php
+++ b/publishable/config/larecipe.php
@@ -47,13 +47,19 @@ return [
     | These options configure the additional behaviors of your documentation
     | where you can limit the access to only authenticated users in your
     | system. It is false initially so that guests can view your docs.
+    | Middleware can be defined, but should not be left blank. For example,
+    | if you want all users to be able to access your docs, use wed middleware.
+    | If you want just auth users, use auth middleware. Or, make your own middleware
+    | to handle who can see your docs (don't forget to use gates for more granular control!).
     |
     |
     */
 
     'settings'       => [
-        'auth'       => false,
-        'ga_id'      => ''
+        'ga_id'      => '',
+        'middleware' => [
+            'web',
+        ]
     ],
 
     /*

--- a/publishable/config/larecipe.php
+++ b/publishable/config/larecipe.php
@@ -47,15 +47,15 @@ return [
     | These options configure the additional behaviors of your documentation
     | where you can limit the access to only authenticated users in your
     | system. It is false initially so that guests can view your docs.
-    | Middleware can be defined, but should not be left blank. For example,
-    | if you want all users to be able to access your docs, use wed middleware.
-    | If you want just auth users, use auth middleware. Or, make your own middleware
+    | Middleware can be defined if auth is set to false. For example, if you want all users to be able to access your docs,
+    | use web middleware. If you want just auth users, use auth middleware. Or, make your own middleware
     | to handle who can see your docs (don't forget to use gates for more granular control!).
     |
     |
     */
 
     'settings'       => [
+        'auth'       => false,
         'ga_id'      => '',
         'middleware' => [
             'web',

--- a/src/Http/Controllers/DocumentationController.php
+++ b/src/Http/Controllers/DocumentationController.php
@@ -20,9 +20,7 @@ class DocumentationController extends Controller
     {
         $this->documentationRepository = $documentationRepository;
 
-        if (config('larecipe.settings.auth')) {
-            $this->middleware(['auth']);
-        }
+        $this->middleware(config('larecipe.settings.middleware'));
     }
 
     /**

--- a/src/Http/Controllers/DocumentationController.php
+++ b/src/Http/Controllers/DocumentationController.php
@@ -20,7 +20,13 @@ class DocumentationController extends Controller
     {
         $this->documentationRepository = $documentationRepository;
 
-        $this->middleware(config('larecipe.settings.middleware'));
+        if (config('larecipe.settings.auth')) {
+            $this->middleware(['auth']);
+        }else{
+            if(config('larecipe.settings.middleware')){
+                $this->middleware(config('larecipe.settings.middleware'));
+            }
+        }
     }
 
     /**

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -19,7 +19,14 @@ class SearchController extends Controller
     {
         $this->documentationRepository = $documentationRepository;
 
-        $this->middleware(config('larecipe.settings.middleware'));
+        if (config('larecipe.settings.auth')) {
+            $this->middleware(['auth']);
+        }else{
+            if(config('larecipe.settings.middleware')){
+                $this->middleware(config('larecipe.settings.middleware'));
+            }
+        }
+
     }
 
     /**

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -19,9 +19,7 @@ class SearchController extends Controller
     {
         $this->documentationRepository = $documentationRepository;
 
-        if (config('larecipe.settings.auth')) {
-            $this->middleware(['auth']);
-        }
+        $this->middleware(config('larecipe.settings.middleware'));
     }
 
     /**

--- a/tests/Feature/ShowDocumentationTest.php
+++ b/tests/Feature/ShowDocumentationTest.php
@@ -25,9 +25,7 @@ class ShowDocumentationTest extends TestCase
         Config::set('larecipe.docs.landing', 'foo');
 
         // set auth to false
-        //Config::set('larecipe.settings.auth', false);  //this is deprecated with new middleware config setting and use in __construct for DocumentationController and SearchController
-        //set middleware to 'web' to simulate guest access
-        Config::set('larecipe.settings.middleware', ['web']);
+        Config::set('larecipe.settings.auth', false);
         
         // guest can view foo page
         $this->get('/docs/1.0')
@@ -74,12 +72,9 @@ class ShowDocumentationTest extends TestCase
     }
 
     /** @test */
-    public function only_auth_user_can_visit_docs_if_auth_middleware_is_set()
+    public function only_auth_user_can_visit_docs_if_auth_option_is_enabled()
     {
-        //Config::set('larecipe.settings.auth', true); //this is deprecated with new middleware config setting and use in __construct for DocumentationController and SearchController
-
-        //set middleware to 'auth' to simulate auth only access
-        Config::set('larecipe.settings.middleware', ['auth']);
+        Config::set('larecipe.settings.auth', true);
 
         $this->get('/docs/1.0')->assertRedirect('login');
     }
@@ -92,6 +87,17 @@ class ShowDocumentationTest extends TestCase
         });
 
         $this->get('/docs/1.0')->assertStatus(403);
+    }
+
+    /** @test
+     * @author wgoldstein@planelogix.com
+     */
+    public function only_auth_user_can_visit_docs_if_auth_middleware_is_set()
+    {
+        //set middleware to 'auth' to simulate auth only access
+        Config::set('larecipe.settings.middleware', ['auth']);
+
+        $this->get('/docs/1.0')->assertRedirect('login');
     }
 
     /** @test

--- a/tests/Feature/ShowDocumentationTest.php
+++ b/tests/Feature/ShowDocumentationTest.php
@@ -25,7 +25,9 @@ class ShowDocumentationTest extends TestCase
         Config::set('larecipe.docs.landing', 'foo');
 
         // set auth to false
-        Config::set('larecipe.settings.auth', false);
+        //Config::set('larecipe.settings.auth', false);  //this is deprecated with new middleware config setting and use in __construct for DocumentationController and SearchController
+        //set middleware to 'web' to simulate guest access
+        Config::set('larecipe.settings.middleware', ['web']);
         
         // guest can view foo page
         $this->get('/docs/1.0')
@@ -72,9 +74,12 @@ class ShowDocumentationTest extends TestCase
     }
 
     /** @test */
-    public function only_auth_user_can_visit_docs_if_auth_option_is_enabled()
+    public function only_auth_user_can_visit_docs_if_auth_middleware_is_set()
     {
-        Config::set('larecipe.settings.auth', true);
+        //Config::set('larecipe.settings.auth', true); //this is deprecated with new middleware config setting and use in __construct for DocumentationController and SearchController
+
+        //set middleware to 'auth' to simulate auth only access
+        Config::set('larecipe.settings.middleware', ['auth']);
 
         $this->get('/docs/1.0')->assertRedirect('login');
     }
@@ -87,5 +92,19 @@ class ShowDocumentationTest extends TestCase
         });
 
         $this->get('/docs/1.0')->assertStatus(403);
+    }
+
+    /** @test
+     * @author wgoldstein@planelogix.com
+     */
+    public function auth_or_public_user_can_visit_docs_if_web_middleware_is_set()
+    {
+        // set the docs path and landing
+        Config::set('larecipe.docs.path', 'tests/views/docs');
+        Config::set('larecipe.docs.landing', 'foo');
+
+        Config::set('larecipe.settings.middleware', ['web']);
+
+        $this->get('/docs/1.0')->assertOk();
     }
 }


### PR DESCRIPTION
Previous functionality had lack of flexibility with middleware. This meant significant limitations with how you can allow guest and auth users to view docs. If auth was set to true, guests could not see your docs. But often times it's nice to have a subset of docs that are public, a subset that are for users, and at least one more subset for, perhaps, admins.

This PR will check the `larecipe.settings.middleware` if auth is set to false, and use those middleware settings to determine if the guest/user should be able to view the docs. Gates can then be used from there for more granular control.

Setting `larecipe.settings.auth` to true will have the same results/effects as before this PR and any middleware settings will be ignored, therefore this is backwards compatible.

I can update the larecipe-docs if this PR is accepted. Unit tests are passing on my end, but I couldn't get it to run on Travis. On Travis most were failing with a 500 error such as:

```
Class 'BinaryTorch\LaRecipe\LaRecipe' not found (View: /home/travis/build/WillGoldstein/larecipe/resources/views/default.blade.php) (View: /home/travis/build/WillGoldstein/larecipe/resources/views/default.blade.php)
```

This will close out #158 .