### PR TITLE
Allow custom ordering of theme styles.

### DIFF
--- a/publishable/config/larecipe.php
+++ b/publishable/config/larecipe.php
@@ -122,6 +122,8 @@ return [
             'primary'    => '#787AF6',
             'secondary'  => '#2b9cf2'
         ],
+
+        'theme_order'    => null // ['LaRecipeDarkTheme', 'customTheme']
     ],
 
     /*

--- a/src/Larecipe.php
+++ b/src/Larecipe.php
@@ -73,6 +73,16 @@ class LaRecipe
      */
     public static function allStyles()
     {
-        return static::$styles;
+        $styles = static::$styles;
+
+        if (config('larecipe.ui.theme_order')) {
+            $newStyleOrder = [];
+            foreach (config('larecipe.ui.theme_order') as $styleName) {
+                $newStyleOrder[$styleName] = $styles[$styleName];
+            }
+            $styles = $newStyleOrder;
+        }
+
+        return $styles;
     }
 }


### PR DESCRIPTION
Adds a new configuration option under 'larecipe.ui' with a default of null. If the config is null, it will load all styles alphabetically, however you can set a specific order for which the theme styles should be loaded.

Use case, you want to use the dark or another custom theme and make minor adjustments but due to alphabetical case your custom gets loaded before the dark theme, this allows you to make sure the dark theme is loaded before your customizations.