### PR TITLE
remove base url, fixes header links

### DIFF
--- a/resources/views/default.blade.php
+++ b/resources/views/default.blade.php
@@ -46,8 +46,6 @@
             <link rel="stylesheet" href="{{ route('larecipe.styles', $name) }}">
         @endforeach
 		
-		<!-- Base url -->
-		<base href="{{ Config::get('app.url') }}/" />
     </head>
     <body>
         <div id="app" v-cloak>


### PR DESCRIPTION
Fixes issue #161 

When the links for most things seem to be linked back to the main application URL rather then the docs url. I tested it without having the base URL and everything seems to work fine with no other changes necessary.