### PR TITLE
Allow remote asset URLs & empty favicon fix

### DIFF
--- a/resources/views/default.blade.php
+++ b/resources/views/default.blade.php
@@ -43,9 +43,13 @@
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
         @foreach(LaRecipe::allStyles() as $name => $path)
-            <link rel="stylesheet" href="{{ route('larecipe.styles', $name) }}">
+            @if (preg_match('/^https?:\/\//', $path))
+                <link rel="stylesheet" href="{{ $path }}">
+            @else
+                <link rel="stylesheet" href="{{ route('larecipe.styles', $name) }}">
+            @endif
         @endforeach
-		
+
     </head>
     <body>
         <div id="app" v-cloak>
@@ -89,7 +93,11 @@
         <!-- /Google Analytics -->
 
         @foreach (LaRecipe::allScripts() as $name => $path)
-            <script src="{{ route('larecipe.scripts', $name) }}"></script>
+            @if (preg_match('/^https?:\/\//', $path))
+                <script src="{{ $path }}"></script>
+            @else
+                <script src="{{ route('larecipe.scripts', $name) }}"></script>
+            @endif
         @endforeach
 
         <script>

--- a/resources/views/default.blade.php
+++ b/resources/views/default.blade.php
@@ -26,9 +26,11 @@
         <!-- CSS -->
         <link rel="stylesheet" href="{{ larecipe_assets('css/app.css') }}">
 
-        <!-- Favicon -->
-        <link rel="apple-touch-icon" href="{{ asset(config('larecipe.ui.fav')) }}">
-        <link rel="shortcut icon" type="image/png" href="{{ asset(config('larecipe.ui.fav')) }}"/>
+        @if (config('larecipe.ui.fav'))
+            <!-- Favicon -->
+            <link rel="apple-touch-icon" href="{{ asset(config('larecipe.ui.fav')) }}">
+            <link rel="shortcut icon" type="image/png" href="{{ asset(config('larecipe.ui.fav')) }}"/>
+        @endif
 
         <!-- FontAwesome -->
         <link rel="stylesheet" href="{{ larecipe_assets('css/font-awesome.css') }}">

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -8,6 +8,20 @@ use BinaryTorch\LaRecipe\Tests\TestCase;
 class ConfigurationTest extends TestCase
 {
     /** @test */
+    public function favicon_is_visible_only_if_ui_fav_is_set()
+    {
+        Config::set('larecipe.ui.fav', '');
+        $this->get('/docs/1.0')
+            ->assertDontSee('rel="apple-touch-icon"')
+            ->assertDontSee('rel="shortcut icon"');
+
+        Config::set('larecipe.ui.fav', 'http://localhost/favicon.ico');
+        $this->get('/docs/1.0')
+            ->assertSee('rel="apple-touch-icon" href="http://localhost/favicon.ico"')
+            ->assertSee('rel="shortcut icon" type="image/png" href="http://localhost/favicon.ico"');
+    }
+
+    /** @test */
     public function ga_script_is_visible_only_if_ga_id_is_set()
     {
         Config::set('larecipe.settings.ga_id', '');
@@ -76,7 +90,7 @@ class ConfigurationTest extends TestCase
         Config::set('larecipe.forum.enabled', false);
         $this->get('/docs/1.0')
             ->assertDontSee('disqus_thread');
-            
+
         Config::set('larecipe.forum.default', 'disqus');
         Config::set('larecipe.forum.enabled', true);
         Config::set('larecipe.forum.services.disqus.site_name', 'larecipe');


### PR DESCRIPTION
There are two parts to this PR :
1. Added support for remote asset URLs when adding assets with `LaRecipe::script()` or `LaRecipe::style()`
2. Fixed issue where favicon links are added to the template when the config option `larecipe.ui.fav` is empty (default value)

**Part 1 - Remote Asset URLs**
Our product uploads all of our built assets to a CDN on deployment. We add assets to LaRecipe through a service provider like so:

```php
        // Add js scripts that will be injected into the larecipe layout
        $scripts = webpack_mix_collection(['larecipe', 'larecipeStyles'], 'js');
        foreach ($scripts as $key => $script) {
            LaRecipe::script('larecipe-' . $key, cdn_asset($script));
        }

        // Add css styles that will be injected into the larecipe layout
        $styles = webpack_mix_collection(['larecipeStyles'], 'css');
        foreach ($styles as $key => $style) {
            LaRecipe::style('larecipe-' . $key, cdn_asset($style));
        }
```

There is a massive performance improvement if LaRecipe can simply add the remote URL as the src of the scripts/styles instead of routing through the ScriptController/StyleController endpoints.

I wasn't sure if this feature should be switched on/off through a config option. Let me know if you think I should add that.

**Part 2 - Favicon Fix**
I noticed that with the default value of `''` for the `larecipe.ui.fav` config option, the template still added the `<link rel="apple-touch-icon" />` and `<link rel="shortcut icon" />` tags, which caused the browser to make requests to the root URL of our application. The fix makes these conditional based on the config value not being falsey.