### PR TITLE
Fix failing configuration test

### DIFF
--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -12,13 +12,13 @@ class ConfigurationTest extends TestCase
     {
         Config::set('larecipe.ui.fav', '');
         $this->get('/docs/1.0')
-            ->assertDontSee('rel="apple-touch-icon"')
-            ->assertDontSee('rel="shortcut icon"');
+            ->assertDontSee('rel="apple-touch-icon"', false)
+            ->assertDontSee('rel="shortcut icon"', false);
 
         Config::set('larecipe.ui.fav', 'http://localhost/favicon.ico');
         $this->get('/docs/1.0')
-            ->assertSee('rel="apple-touch-icon" href="http://localhost/favicon.ico"')
-            ->assertSee('rel="shortcut icon" type="image/png" href="http://localhost/favicon.ico"');
+            ->assertSee('rel="apple-touch-icon" href="http://localhost/favicon.ico"', false)
+            ->assertSee('rel="shortcut icon" type="image/png" href="http://localhost/favicon.ico"', false);
     }
 
     /** @test */


### PR DESCRIPTION
Currently the `ConfigurationTest::favicon_is_visible_only_if_ui_fav_is_set` test is failing, also see the GitHub action run: https://github.com/saleem-hadad/larecipe/runs/494342595.

The test is failing due to the fact that double quotes are currently escaped, comparing `"` in the response to `&quot;`. 

## Fix: disable escaping of double quotes in the assertion calls.
This PR adds a second argument to the `assertSee()` and `assertDontSee()` calls to prevent the double quote from being escaped to `&quot;`.