### PR TITLE
Exclude code blocks from Blade compilation

### DIFF
--- a/publishable/config/larecipe.php
+++ b/publishable/config/larecipe.php
@@ -194,5 +194,14 @@ return [
 
     'packages' => [
         'path' => 'larecipe-components',
+    ],
+
+    'blade-parser' => [
+        'regex' => [
+            'code-blocks' => [
+                'match' => '/\<pre\>(.|\n)*<\/pre\>/',
+                'replacement' => '<code-block>',
+            ]
+        ]
     ]
 ];

--- a/tests/Unit/DocumentationTest.php
+++ b/tests/Unit/DocumentationTest.php
@@ -76,4 +76,11 @@ class DocumentationTest extends TestCase
         $content = "{{ count(['foo', 'bar']) }}";
         $this->assertEquals(2, $this->documentation->renderBlade($content));
     }
+
+    /** @test */
+    public function it_does_not_render_blade_content_within_code_blocks()
+    {
+        $content = "<pre><code>{{ count(['foo', 'bar']) }}</code></pre>";
+        $this->assertEquals($content, $this->documentation->renderBlade($content));
+    }
 }


### PR DESCRIPTION
## The issue
This PR addresses issue #168, in which an `Exception` is thrown when using Blade syntax within code blocks. This issue arises from the fact that currently the whole page is rendered through a Blade compiler, including the code blocks.

## What has been done
- Added `compileBlade` method, in which code blocks are first stripped from the documentation content after which compilation is performed and finally the stubbed out code blocks are replaced by their original contents. 
- Stored matching and replacement regex patterns in `config`.
- Added a PHPunit test, asserting blade syntax is not compiled within code blocks.

## Example of code block with Blade syntax
<img width="435" alt="Schermafbeelding 2020-03-29 om 14 28 48" src="https://user-images.githubusercontent.com/24190396/77849129-9cb9aa00-71c9-11ea-87f0-a9b68015eb48.png">

Please let me know if you have any suggestions or additions.

PS: currently the tests are failing, see #205.