### PR TITLE
Permit blade directives in index.md

### DIFF
--- a/src/Models/Documentation.php
+++ b/src/Models/Documentation.php
@@ -52,7 +52,9 @@ class Documentation
             if ($this->files->exists($path)) {
                 $parsedContent = $this->parse($this->files->get($path));
 
-                return $this->replaceLinks($version, $parsedContent);
+                $parsedContent = $this->replaceLinks($version, $parsedContent);
+
+                return $this->renderBlade($parsedContent, []);
             }
 
             return null;


### PR DESCRIPTION
This edit is made to resolve the problem to hide some links in the index, based on a custom gate.
Example:

index.md
``` 
@if(Gate::allows('viewLarecipe', 'admin'))
    - [Setup](/{{route}}/{{version}}/setup)
@endif
```

 Gate
```
Gate::define('viewLarecipe', function(?Utente $user, $documentation) {
    if($user->isAdmin()) {
        return true;
    }

    // when called in index, $documentation is a string
    $title = strtolower($documentation->title ?? $documentation);
    if(strpos($titolo, "setup") !== false){
        return false;
     }
     return true;
});
```