### PR TITLE
Fix get pages regular expression

### DIFF
--- a/src/Traits/Indexable.php
+++ b/src/Traits/Indexable.php
@@ -17,7 +17,11 @@ trait Indexable
 
             $result = [];
             foreach($pages as $page) {
-                $page = explode("{{version}}", $page)[1];
+                $split = explode("{{version}}", $page);
+                if (count($split) <= 1)
+                    continue;
+
+                $page = $split[1];
                 $pageContent = $this->get($version, $page);
 
                 if(! $pageContent)
@@ -57,7 +61,7 @@ trait Indexable
         $path = base_path(config('larecipe.docs.path').'/'.$version.'/index.md');
 
         // match all markdown urls => [title](url)
-        preg_match_all('/\(([^)]+)\)/', $this->files->get($path), $matches);
+        preg_match_all('/\[.+\]\((.+)\)/', $this->files->get($path), $matches);
 
         return $matches[1];
     }


### PR DESCRIPTION
A 500 error occurs when searching with the `internal` engine if you have brackets inside sidebar text.

Example:
```
- ## Example
    - [80 / 443 HTTP(S)](/{{route}}/{{version}}/example/http)
```

This causes the `$page` parameter to contain "S" in this scenario instead of "/{{route}}/{{version}}/example/http". To prevent the error, I have added a validation check on the explode array to make sure it contains more than 1 element.

To fix the issue itself, i've updated the regular expression from `\(([^)]+)\)` to `\[.+\]\((.+)\)`. This expects a [something] before the brackets (url) which I believe should always exist for a valid markdown link.