### PR TITLE
Allow using a custom guard for authorization by setting config

### DIFF
--- a/publishable/config/larecipe.php
+++ b/publishable/config/larecipe.php
@@ -56,6 +56,7 @@ return [
 
     'settings'       => [
         'auth'       => false,
+        'guard'      => null,
         'ga_id'      => '',
         'middleware' => [
             'web',

--- a/src/Http/Controllers/DocumentationController.php
+++ b/src/Http/Controllers/DocumentationController.php
@@ -2,6 +2,7 @@
 
 namespace BinaryTorch\LaRecipe\Http\Controllers;
 
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use BinaryTorch\LaRecipe\DocumentationRepository;
 
@@ -19,6 +20,10 @@ class DocumentationController extends Controller
     public function __construct(DocumentationRepository $documentationRepository)
     {
         $this->documentationRepository = $documentationRepository;
+
+        if (config('larecipe.settings.guard')) {
+            Auth::shouldUse(config('larecipe.settings.guard'));
+        }
 
         if (config('larecipe.settings.auth')) {
             $this->middleware(['auth']);


### PR DESCRIPTION
I have come across your lovely package, but my project uses several custom guards which means that `$this->authorize('viewLarecipe', $documentation)` will always fail, as the `web` gaurd's `$user` will always be `null`.

This is a pretty straightforward PR that is non-breaking, but allows people to use custom guards to protect their LaRecipe Docs.