### PR TITLE
Added the option to create pages for different products.

### DIFF
--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -31,6 +31,28 @@
                 <i class="fab fa-github"></i>
             </larecipe-button>
 
+            @if($products && !empty($products))
+            <larecipe-dropdown class="mx-2 px-4">
+                <larecipe-button type="primary" class="flex">
+                    {{ $product ?? "Default" }} <i class="mx-2 fa fa-angle-down"></i>
+                </larecipe-button>
+
+                <template slot="list">
+                    <ul class="list-reset">
+                        @foreach ($products as $productItem)
+                            <li class="py-2 hover:bg-grey-lightest">
+                                @if ($productItem == "larecipe_default")
+                                    <a class="px-6 text-grey-darkest" href="{{ route('larecipe.show', ['version' => $currentVersion, 'page' => $currentSection]) }}">{{ "Default" }}</a>
+                                @else
+                                    <a class="px-6 text-grey-darkest" href="{{ route('larecipe.show.product', [ 'version' => $currentVersion, 'page' => $currentSection, 'product' => $productItem]) }}">{{ $productItem }}</a>
+                                @endif
+                            </li>
+                        @endforeach
+                    </ul>
+                </template>
+            </larecipe-dropdown>
+            @endif
+
             {{-- versions dropdown --}}
             <larecipe-dropdown>
                 <larecipe-button type="primary" class="flex">
@@ -41,7 +63,11 @@
                     <ul class="list-reset">
                         @foreach ($versions as $version)
                             <li class="py-2 hover:bg-grey-lightest">
-                                <a class="px-6 text-grey-darkest" href="{{ route('larecipe.show', ['version' => $version, 'page' => $currentSection]) }}">{{ $version }}</a>
+                                @if ($product)
+                                    <a class="px-6 text-grey-darkest" href="{{ route('larecipe.show.product', ['version' => $version, 'page' => $currentSection, 'product' => $product ]) }}">{{ $version }}</a>
+                                @else
+                                    <a class="px-6 text-grey-darkest" href="{{ route('larecipe.show', ['version' => $version, 'page' => $currentSection]) }}">{{ $version }}</a>
+                                @endif
                             </li>
                         @endforeach
                     </ul>

--- a/routes/LaRecipe.php
+++ b/routes/LaRecipe.php
@@ -11,4 +11,8 @@ Route::get('/scripts/{script}', 'ScriptController')->name('scripts');
 
 // Documentation..
 Route::get('/', 'DocumentationController@index')->name('index');
+
+Route::get('/{product}/{version}/{page?}', 'DocumentationController@showProduct')->where('version','[0-9].[0-9]')->where('product','^[0-9a-zA-Z/ -]+$')->name('show.product');
+
 Route::get('/{version}/{page?}', 'DocumentationController@show')->where('page', '(.*)')->name('show');
+

--- a/src/Traits/HasDocumentationAttributes.php
+++ b/src/Traits/HasDocumentationAttributes.php
@@ -7,6 +7,7 @@ trait HasDocumentationAttributes
     protected $title;
     protected $index;
     protected $version;
+    protected $product;
     protected $content;
     protected $canonical;
     protected $docsRoute;

--- a/src/Traits/HasProducts.php
+++ b/src/Traits/HasProducts.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace BinaryTorch\LaRecipe\Traits;
+
+trait HasProducts
+{
+    /**
+     * Gets all products of current documentation
+     *
+     * @param string[] $publishedVersions Documentation published versions
+     * @return string[]|null
+     */
+    public function getProducts($publishedVersions)
+    {
+        $hasDefault = false;
+        $products = [];
+        foreach ($publishedVersions as $key => $version) {
+            if (is_array($version))
+                array_push($products, $key);
+            else
+                $hasDefault = true;
+        }
+
+        return empty($products) ? null : (!$hasDefault ?  $products : array_merge(array("larecipe_default"), $products));
+    }
+    /**
+     * Gets all default published version (when is not any product)
+     *
+     * @param [type] $publishedVersions Documentation published versions
+     * @return void
+     */
+    public function getVersions($publishedVersions)
+    {
+        $versions = array();
+
+        foreach ($publishedVersions as $simpleVersion) {
+            if (!is_array($simpleVersion))
+                array_push($versions, (string)$simpleVersion);
+        }
+        return empty($versions) ? null : $versions;
+    }
+    /**
+     * Gets all published version of product
+     *
+     * @param [type] $publishedVersions Documentation published versions
+     * @param [type] $product Current product name
+     * @return void
+     */
+    public function getProductVersions($publishedVersions, $product)
+    {
+        if (isset($publishedVersions[$product]))
+            return $publishedVersions[$product];
+        return null;
+    }
+}


### PR DESCRIPTION
I had the need to create a documentation for several products corresponding to the same service.

For this I have made some changes that allow creating "Products" before a version and versioning them individually.

I devised a series of minimal conditions for the update to be possible.

- [x] Don't break any current integration.
- [x] Do not require products.
- [x] Allow versioning of all products.
- [x] Compatibility between several products and their versions.
- [x] Compatibility between products and default version (without being a product).
- [x] Correct redirections between routes.
- [x] Adaptation of the UI of the views to navigate between products and versions.
- [ ] Default products (Would it be necessary?)
- [ ] Accept that there are only products. (WIP)

**What does this update do?**

Previously you could only have versions in your configuration:

![image](https://user-images.githubusercontent.com/32484496/115912456-a4e92500-a46f-11eb-9de8-42cc263c8f2a.png)

Now you can create products, with versions:

![image](https://user-images.githubusercontent.com/32484496/115912501-b3374100-a46f-11eb-9baa-dae36724449e.png)

or several:

![image](https://user-images.githubusercontent.com/32484496/115912537-bcc0a900-a46f-11eb-86e3-e160872bc155.png)

You can also, just create products:

![image](https://user-images.githubusercontent.com/32484496/115912820-1aed8c00-a470-11eb-88b4-228b940e5ed6.png)

⤴ If you do this, the default version will give problems (You will have to redirect the user directly to a product), **WIP**.

A product would look like this:

![image](https://user-images.githubusercontent.com/32484496/115913498-f7771100-a470-11eb-99d3-ba7a5287ac8e.png)

With their versions:

![image](https://user-images.githubusercontent.com/32484496/115913584-137ab280-a471-11eb-83b8-f70e26375212.png)

If you add a version without product:

```php
 'versions'      => [
        'default'   => '1.0',
        'published' => [
            '1.0', //No product
            'Shield' => ['1.0','2.0'],
            'Shield-Cli' => ['1.0'],
            'Shield-Vs' => ['1.0'],
        ]
    ],
```
It will be parsed as default:

![image](https://user-images.githubusercontent.com/32484496/115913784-55a3f400-a471-11eb-9301-effe8e20781c.png)

The hierarchy remains the same; using folders for the products and inside their versions:

![image](https://user-images.githubusercontent.com/32484496/115913920-87b55600-a471-11eb-98e3-fdd459a5b9f1.png)


And in the routes, the current product will be parsed automatically:

![image](https://user-images.githubusercontent.com/32484496/115914003-a3b8f780-a471-11eb-9190-cbe9e004ce2c.png)

It remains to add test, and solve the problem of the `default -> version` when there is no version without product.

The reason for the pull is to know if it seems useful to someone else and some other suggestion, I have personally tested it and I do not find problems, automatic tests are missing.

Important, if it is used in an application that already contains it, it is necessary to update the partial views again.

All the best,