### PR TITLE
Retrieve Markdown parser from Application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `larecipe` will be documented in this file
 - Add support for Laravel 8 - ([#235](https://github.com/saleem-hadad/larecipe/pull/235))
 - Permit show blade directives - ([#234](https://github.com/saleem-hadad/larecipe/pull/234))
 - Exclude code blocks from Blade compilation - ([#206](https://github.com/saleem-hadad/larecipe/pull/206))
+- Markdown is now parsed against a contract, allowing you to change it - ([#252](https://github.com/saleem-hadad/larecipe/issues/252))
 
 <a name="2.3.0"></a>
 # [2.3.0](https://github.com/saleem-hadad/larecipe/releases/tag/v2.3.0) (2020-03-09)

--- a/src/Contracts/MarkdownParser.php
+++ b/src/Contracts/MarkdownParser.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BinaryTorch\LaRecipe\Contracts;
+
+interface MarkdownParser
+{
+    /**
+     * Parse the given source to Markdown, using your Markdown parser of choice.
+     *
+     * @param string $source
+     * @return null|string|string[]
+     */
+    public function parse($source);
+}

--- a/src/LaRecipeServiceProvider.php
+++ b/src/LaRecipeServiceProvider.php
@@ -7,6 +7,8 @@ use Illuminate\Support\ServiceProvider;
 use BinaryTorch\LaRecipe\Commands\AssetCommand;
 use BinaryTorch\LaRecipe\Commands\ThemeCommand;
 use BinaryTorch\LaRecipe\Commands\InstallCommand;
+use BinaryTorch\LaRecipe\Contracts\MarkdownParser;
+use BinaryTorch\LaRecipe\Services\ParseDownMarkdownParser;
 use BinaryTorch\LaRecipe\Facades\LaRecipe as LaRecipeFacade;
 use BinaryTorch\LaRecipe\Commands\GenerateDocumentationCommand;
 
@@ -53,6 +55,8 @@ class LaRecipeServiceProvider extends ServiceProvider
             $this->registerPublishableResources();
             $this->registerConsoleCommands();
         }
+
+        $this->app->bind(MarkdownParser::class, ParseDownMarkdownParser::class);
 
         $this->app->alias('LaRecipe', LaRecipeFacade::class);
 

--- a/src/Services/ParseDownMarkdownParser.php
+++ b/src/Services/ParseDownMarkdownParser.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BinaryTorch\LaRecipe\Services;
+
+use ParsedownExtra;
+use BinaryTorch\LaRecipe\Contracts\MarkdownParser;
+
+class ParseDownMarkdownParser implements MarkdownParser
+{
+    /**
+     * Parse the given source to Markdown, using your Markdown parser of choice.
+     *
+     * @param string $source Markdown source contents
+     * @return null|string|string[] HTML output
+     */
+    public function parse($source)
+    {
+        return (new ParsedownExtra)->text($source);
+    }
+}

--- a/src/Traits/HasMarkdownParser.php
+++ b/src/Traits/HasMarkdownParser.php
@@ -2,7 +2,8 @@
 
 namespace BinaryTorch\LaRecipe\Traits;
 
-use ParsedownExtra;
+use Illuminate\Support\Facades\App;
+use BinaryTorch\LaRecipe\Contracts\MarkdownParser;
 
 trait HasMarkdownParser
 {
@@ -13,6 +14,6 @@ trait HasMarkdownParser
      */
     public function parse($text)
     {
-        return (new ParsedownExtra)->text($text);
+        return App::make(MarkdownParser::class)->parse($text);
     }
 }

--- a/tests/Feature/InterchangeableMarkdownParserTest.php
+++ b/tests/Feature/InterchangeableMarkdownParserTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BinaryTorch\LaRecipe\Tests\Feature;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use BinaryTorch\LaRecipe\Tests\TestCase;
+use BinaryTorch\LaRecipe\Contracts\MarkdownParser;
+use BinaryTorch\LaRecipe\Tests\Fixtures\HelloWorldMarkdownParser;
+
+class InterchangeableMarkdownParserTest extends TestCase
+{
+    /** @test */
+    public function a_parser_is_accepted_as_long_as_the_contract_matches()
+    {
+        // set the docs path and landing
+        Config::set('larecipe.docs.path', 'tests/views/docs');
+        Config::set('larecipe.docs.landing', 'foo');
+
+        // set auth to false
+        Config::set('larecipe.settings.auth', false);
+
+        // Provide a dummy parser
+        $randomId = (string) Str::uuid();
+        App::instance(MarkdownParser::class, new HelloWorldMarkdownParser($randomId));
+
+        // guest can view foo page
+        $this->get('/docs/1.0')
+            ->assertViewHasAll([
+                'title',
+                'index',
+                'content',
+                'currentVersion',
+                'versions',
+                'currentSection',
+                'canonical'
+            ])
+            ->assertSee("<h1>{$randomId}</h1>", false)
+            ->assertDontSee('<h1>Foo</h1>', false)
+            ->assertStatus(200);
+    }
+}

--- a/tests/Fixtures/HelloWorldMarkdownParser.php
+++ b/tests/Fixtures/HelloWorldMarkdownParser.php
@@ -1,0 +1,23 @@
+<?php
+namespace BinaryTorch\LaRecipe\Tests\Fixtures;
+
+use BinaryTorch\LaRecipe\Contracts\MarkdownParser;
+
+class HelloWorldMarkdownParser implements MarkdownParser
+{
+    private $suffix;
+
+    public function __construct(string $suffix)
+    {
+        $this->suffix = $suffix;
+    }
+
+    public function parse($source)
+    {
+        return <<<HTML
+        <h1>{$this->suffix}</h1>
+
+        This is a test client, don't use in any other application!
+        HTML;
+    }
+}


### PR DESCRIPTION
Changing the markdown provider could be quite an API change, but instead I elected to add a small PSR Container layer inbetween, to leave the functioning identical to the current behaviour.

I didn't add a commonmark parser yet, but that's one extra commit away, if that's deemed required.

Added tests using a super dumb parser, since "parsing markdown" isn't exactly bound to contracts.

Helps with #252