### PR TITLE
Feature/display authors names from git repo

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -5,6 +5,15 @@
 	@include('larecipe::partials.sidebar')
 	
 	<div class="documentation is-{{ config('larecipe.ui.code_theme') }}" :class="{'expanded': ! sidebar}">
+		@if($authors)
+			<div class="text-xs text-grey-darker mb-6">
+				@if(($authorsCount = count($authors)) > 1)
+					{{$authorsCount}} authors ($authors[0]['name'] and others)
+				@else
+					By {{$authors[0]['name']}}
+				@endif
+			</div>
+		@endif
 		{!! $content !!}
 		@include('larecipe::plugins.forum')
 	</div>

--- a/src/Http/Controllers/DocumentationController.php
+++ b/src/Http/Controllers/DocumentationController.php
@@ -84,6 +84,7 @@ class DocumentationController extends Controller
             'versions'       => $documentation->publishedVersions,
             'currentSection' => $documentation->currentSection,
             'canonical'      => $documentation->canonical,
+            'authors'        => $documentation->authors,
         ], $documentation->statusCode);
     }
 }

--- a/src/Traits/HasDocumentationAttributes.php
+++ b/src/Traits/HasDocumentationAttributes.php
@@ -16,6 +16,7 @@ trait HasDocumentationAttributes
     protected $statusCode = 200;
     protected $publishedVersions;
     protected $defaultVersionUrl;
+    protected $authors;
 
     /**
      * @return string
@@ -87,5 +88,13 @@ trait HasDocumentationAttributes
     public function getPublishedVersionsAttribute()
     {
         return $this->publishedVersions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAuthorsAttribute()
+    {
+        return $this->authors;
     }
 }


### PR DESCRIPTION
Hello there,

This is a draft PR for getting information about each individual page author.
Data about authors are fetched from the GIT repository.

It's an improved version of "Added/updated by - from git" in Future Development issue #6.

These are some examples of the final result:

* A page with one contributor:
![image](https://user-images.githubusercontent.com/16087389/148812594-696ebf25-2208-47c8-b4b1-bfc481b20973.png)

* A page with many contributors:
![image](https://user-images.githubusercontent.com/16087389/148812726-1df0d1be-c6b1-4c75-b326-c8597b32459d.png)

The design is inspired by vs code feature:
![image](https://user-images.githubusercontent.com/16087389/148812852-d74cf4c0-a4dc-4403-aac3-a3430a9317d5.png)


This update needs some refactoring and work. But I wanted to get feedback from the repo owner and the community before implementing the whole feature. So, please feel free to comment if you have any ideas or improvements for this feature.

The remaining tasks to complete this draft:
- [ ] Backend tasks
  - [ ] Extract all git related logic to a separate class.
  - [ ] Check if git is installed before executing the needed commands.
  - [ ] Check if the file is committed in a repository.
  - [ ] Add configuration in the conf file to disable/enable git features.
  - [ ] Cache `git shortlog` command output.
  - [ ] Add tests.
- [ ] Frontend tasks
  - [ ] Refactor authors section
  - [ ] Expand list of authors on click (Maybe I will expand it in a modal, Not sure yet)