### PR TITLE
Publish complete resources for customization

### DIFF
--- a/src/LaRecipeServiceProvider.php
+++ b/src/LaRecipeServiceProvider.php
@@ -80,7 +80,7 @@ class LaRecipeServiceProvider extends ServiceProvider
                 "{$publishablePath}/assets/" => public_path('vendor/binarytorch/larecipe/assets'),
             ],
             'larecipe_views' => [
-                dirname(__DIR__) . "/resources/views/partials" => resource_path('views/vendor/larecipe/partials'),
+                dirname(__DIR__) . "/resources/views" => resource_path('views/vendor/larecipe'),
             ],
         ];
 


### PR DESCRIPTION
## Problem

For projects having separate CDN in Laravel Vapor, the `asset` method used for serving resources creates problem and loads wrong assets leading to site not being load

## Solution

Two ways, either introduce a class which can be overriden for loading asset instead of `larecipe_assets` or publish entire `resources` so each of the blade is customizable