### PR TITLE
Fix formatting issue in config file

### DIFF
--- a/publishable/config/larecipe.php
+++ b/publishable/config/larecipe.php
@@ -158,20 +158,20 @@ return [
         ]
     ],
 
-   /*
-   |--------------------------------------------------------------------------
-   | Forum
-   |--------------------------------------------------------------------------
-   |
-   | Giving a chance to your users to post their questions or feedback
-   | directly on your docs, is pretty nice way to engage them more.
-   | However, you can also enable/disable the forum's visibility.
-   |
-   | Supported Services: 'disqus'
-   |
-   */
+    /*
+    |--------------------------------------------------------------------------
+    | Forum
+    |--------------------------------------------------------------------------
+    |
+    | Giving a chance to your users to post their questions or feedback
+    | directly on your docs, is pretty nice way to engage them more.
+    | However, you can also enable/disable the forum's visibility.
+    |
+    | Supported Services: 'disqus'
+    |
+    */
 
-  'forum'                   => [
+    'forum'                 => [
         'enabled'           => false,
         'default'           => 'disqus',
         'services'          => [


### PR DESCRIPTION
**Issue Description**
The configuration file has a minor formatting issue related to comment block indentation. Most of the comments in the file are correctly indented with 4 spaces. However, there is one comment block that uses 3 spaces for indentation, causing an inconsistency in the file's formatting.

**Proposed Fix**
This pull request aims to address the formatting problem by adjusting the indentation of the specific comment block to use 4 spaces consistently throughout the configuration file.