### PR TITLE
fix: Return 404 if a custom script or style is not found

### DIFF
--- a/src/Http/Controllers/ScriptController.php
+++ b/src/Http/Controllers/ScriptController.php
@@ -14,8 +14,9 @@ class ScriptController extends Controller
     public function __invoke(Request $request)
     {
         return response(
-            file_get_contents(LaRecipe::allScripts()[$request->script]),
-            200, ['Content-Type' => 'application/javascript']
+            file_get_contents(LaRecipe::allScripts()[$request->script] ?? abort(404)),
+            200,
+            ['Content-Type' => 'application/javascript']
         );
     }
 }

--- a/src/Http/Controllers/StyleController.php
+++ b/src/Http/Controllers/StyleController.php
@@ -14,8 +14,9 @@ class StyleController extends Controller
     public function __invoke(Request $request)
     {
         return response(
-            file_get_contents(LaRecipe::allStyles()[$request->style]),
-            200, ['Content-Type' => 'text/css']
+            file_get_contents(LaRecipe::allStyles()[$request->style] ?? abort(404)),
+            200,
+            ['Content-Type' => 'text/css']
         );
     }
 }

--- a/tests/Feature/CustomScriptsTest.php
+++ b/tests/Feature/CustomScriptsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace BinaryTorch\LaRecipe\Tests\Feature;
+
+use BinaryTorch\LaRecipe\LaRecipe;
+use BinaryTorch\LaRecipe\Tests\TestCase;
+
+class CustomScriptsTest extends TestCase
+{
+    /** @test */
+    public function a_script_not_found_returns_404()
+    {
+        $this->get('/docs/scripts/not-found')
+            ->assertNotFound();
+    }
+
+    /** @test */
+    public function a_script_is_returned()
+    {
+        LaRecipe::script('custom-script', __DIR__ . '/../theme/resources/js/custom.js');
+
+        $this->get('/docs/scripts/custom-script')
+            ->assertOk()
+            ->assertHeader('Content-Type', 'application/javascript')
+            ->assertSee('Custom JS');
+    }
+}

--- a/tests/Feature/CustomStylesTest.php
+++ b/tests/Feature/CustomStylesTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace BinaryTorch\LaRecipe\Tests\Feature;
+
+use BinaryTorch\LaRecipe\LaRecipe;
+use BinaryTorch\LaRecipe\Tests\TestCase;
+
+class CustomStylesTest extends TestCase
+{
+    /** @test */
+    public function a_style_not_found_returns_404()
+    {
+        $this->get('/docs/styles/not-found')
+            ->assertNotFound();
+    }
+
+    /** @test */
+    public function a_style_is_returned()
+    {
+        LaRecipe::style('custom-style', __DIR__ . '/../theme/resources/css/custom.css');
+
+        $this->get('/docs/styles/custom-style')
+            ->assertOk()
+            ->assertHeader('Content-Type', 'text/css; charset=UTF-8')
+            ->assertSee('Custom CSS');
+    }
+}

--- a/tests/theme/resources/css/custom.css
+++ b/tests/theme/resources/css/custom.css
@@ -1,0 +1,1 @@
+/** Custom CSS **/

--- a/tests/theme/resources/js/custom.js
+++ b/tests/theme/resources/js/custom.js
@@ -1,0 +1,1 @@
+// Custom JS


### PR DESCRIPTION
My site has gotten hit by a malicious actor several times hitting the routes to load the custom scripts or styles with non-existent scripts/styles.

An example being `/docs/scripts/non-existent-504843668` (with the number being different each time) and `/docs/styles/non-existent-945848484`.

When this happens, we get a ton of errors because when these non-existent scripts/styles try to get loaded, a 500 is thrown with the error `Undefined array key "non-existent-504843668"`.

I have fixed this so instead of a 500 being thrown, a 404 is returned.