### PR TITLE
updating erusev/parsedown-extra version from 0.8.1 to 0.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.1|^8.0",
         "illuminate/support": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "illuminate/view": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "erusev/parsedown-extra": "^0.8.1|^0.8",
+        "erusev/parsedown-extra": "^0.9",
         "symfony/dom-crawler": "^4.1|^5.0|^6.0|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION

# Related Issue
Closed #415 

### Description
This PR updates the `erusev/parsedown-extra` dependency from **v0.8.1** to **v0.9.0** to resolve compatibility issues with **PHP 8.2**.

The issue reported in #415 occurs due to stricter error handling introduced in PHP 8.2, which triggers an **"Undefined array key 'text'"** warning when rendering the documentation.

Version **0.9.0** of `parsedown-extra` includes fixes that properly handle this case and prevent the warning from occurring.

### Result
- Resolves the `Undefined array key "text"` error when accessing the documentation.
- Improves compatibility with **PHP 8.2 or greater**.